### PR TITLE
Disable traefik labels by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,7 +66,7 @@ prometheus_node_exporter_systemd_wanted_services_list: []
 # See `../templates/labels.j2` for details.
 #
 # To inject your own other container labels, see `prometheus_node_exporter_container_labels_additional_labels`.
-prometheus_node_exporter_container_labels_traefik_enabled: "{{ true if prometheus_node_exporter_hostname else false }}"
+prometheus_node_exporter_container_labels_traefik_enabled: false
 prometheus_node_exporter_container_labels_traefik_docker_network: "{{ prometheus_node_exporter_container_network }}"
 prometheus_node_exporter_container_labels_traefik_hostname: "{{ prometheus_node_exporter_hostname }}"
 # The path prefix must either be `/` or not end with a slash (e.g. `/metrics`).


### PR DESCRIPTION
Traefik labels are configured at the playbook level and also takes mash_playbook_traefik_labels_enabled into account.

See https://github.com/mother-of-all-self-hosting/ansible-role-loki/pull/7#issuecomment-2205844791