### PR TITLE
Skip container network creation if host namespace is used

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,6 +32,7 @@
     name: "{{ prometheus_node_exporter_container_network }}"
     driver: bridge
     driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
+  when: prometheus_node_exporter_container_network != 'host'
 
 - name: Ensure prometheus-node-exporter systemd service installed
   ansible.builtin.template:


### PR DESCRIPTION
According to [official documentation](https://hub.docker.com/r/prom/node-exporter) Node Exporter netdev collector could not run properly without access to host network.
This commit allows to skip bridged network creation and assign host namespace to the container.
It can be used within [matrix-docker-ansible-deploy](https://github.com/spantaleev/matrix-docker-ansible-deploy) as follows:
```yaml
prometheus_enabled: true
prometheus_self_node_scraper_enabled: false
prometheus_container_extra_arguments:
  - "--add-host=host.docker.internal:host-gateway"
prometheus_config_scrape_configs_additional:
  - job_name: "{{ prometheus_self_node_scraper_job_name }}"
    scrape_interval: "{{ prometheus_self_node_scraper_scrape_interval }}"
    scrape_timeout: "{{ prometheus_self_node_scraper_scrape_timeout }}"
    static_configs:
    - targets:
      - "host.docker.internal:9100"

prometheus_node_exporter_enabled: true
prometheus_node_exporter_container_network: "host"
prometheus_node_exporter_container_labels_traefik_enabled: false
prometheus_node_exporter_container_additional_networks: []
prometheus_node_exporter_container_extra_arguments:
  - "--add-host=host.docker.internal:host-gateway"
prometheus_node_exporter_process_extra_arguments:
  - "--web.listen-address host.docker.internal:9100"
  - "--collector.netdev.device-exclude=^(br-|veth|lo|docker)"
  - "--collector.netclass.ignored-devices=^(br-|veth|docker|lo)"
```